### PR TITLE
Optimize `createPrimitives`

### DIFF
--- a/src/async-task.ts
+++ b/src/async-task.ts
@@ -1,4 +1,4 @@
-import { createPrimitives, Effect, Effectful, HandleTactics } from './core';
+import { Effect, Effectful, HandleTactics, createPrimitive } from './core';
 import { unsafeRunAsync } from './runners';
 
 /**
@@ -11,7 +11,6 @@ import { unsafeRunAsync } from './runners';
 export type AsyncTask<R = unknown> = Effect<'AsyncTask', {
   wait(promise: Promise<R>): R
 }>
-const _AsyncTask = <R>() => createPrimitives<AsyncTask<R>>('AsyncTask')
 export const AsyncTask = {
   /**
    * 'await' in hyogwa's style
@@ -21,9 +20,7 @@ export const AsyncTask = {
    * @typeParam R - result type of asynchronous task
    * @param promise - a promise to way
    */
-  * wait<R>(promise: Promise<R>): Effectful<AsyncTask<R>, R> {
-    return yield* _AsyncTask<R>().wait(promise)
-  }
+  wait: createPrimitive('AsyncTask', 'wait') as <R>(promise: Promise<R>) => Effectful<AsyncTask<R>, R>
 }
 
 /**

--- a/src/core.ts
+++ b/src/core.ts
@@ -157,6 +157,14 @@ type Primitives<E extends Effects>
  */
 export type NameOfEffect<E extends Effects> = E['construction'] extends `${infer N}.${infer _}` ? N : never
 
+/**
+ * Create primitive operation
+ *
+ * @internal
+ *
+ * @param effectName
+ * @param constructorName
+ */
 function createPrimitive(effectName: string, constructorName: string) {
   const primitive = withName((...parameters: unknown[]) => {
     let isCalled = false

--- a/src/core.ts
+++ b/src/core.ts
@@ -165,7 +165,7 @@ export type NameOfEffect<E extends Effects> = E['construction'] extends `${infer
  * @param effectName
  * @param constructorName
  */
-function createPrimitive(effectName: string, constructorName: string) {
+export function createPrimitive(effectName: string, constructorName: string) {
   const primitive = withName((...parameters: unknown[]) => {
     let isCalled = false
     let isTerminated = false

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,3 +83,15 @@ export function isGenerator(value: unknown): value is Generator {
     && typeof value.throw === 'function'
   )
 }
+
+/**
+ * Utility function to define function with name
+ *
+ * @param f - A function to define name
+ * @param name - A name for function
+ */
+export function withName<F extends Function>(f: F, name: string): F {
+  Reflect.defineProperty(f, 'name', { value: name })
+
+  return f
+}


### PR DESCRIPTION
ECMAScript generator functions are not cheap. Avoiding to use generator function inside library helps it be more performant.