### PR TITLE
Add support for node.js environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 
 node_modules/
+./dist

--- a/package.json
+++ b/package.json
@@ -4,22 +4,22 @@
   "description": "Natural 🌿 effect system that fits TypeScript",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts",
-    "./core": "./src/index.ts",
-    "./runners": "./src/runners.ts",
-    "./assistant": "./src/assistants.ts",
-    "./exception": "./src/exception.ts",
-    "./env": "./src/env.ts",
-    "./state": "./src/state.ts",
-    "./log": "./src/log.ts",
-    "./async-task": "./src/async-task.ts",
-    "./monad": "./src/monad.ts",
-    "./with-handler": "./src/with-handler.ts"
+    ".": "./dist/index.js",
+    "./core": "./dist/index.js",
+    "./runners": "./dist/runners.js",
+    "./assistant": "./dist/assistants.js",
+    "./exception": "./dist/exception.js",
+    "./env": "./dist/env.js",
+    "./state": "./dist/state.js",
+    "./log": "./dist/log.js",
+    "./async-task": "./dist/async-task.js",
+    "./monad": "./dist/monad.js",
+    "./with-handler": "./dist/with-handler.js"
   },
   "sideEffects": false,
   "scripts": {
-    "typecheck": "tsc",
-    "prepare": "npm run typecheck"
+    "build": "tsc",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/assistants.ts
+++ b/src/assistants.ts
@@ -1,5 +1,5 @@
-import { Eq, Unreachable } from './utils';
-import { Effects, Handlers, NameOfEffect, ExcludeHandledEffects, UsedEffectsInHandlers, Effectful } from './core';
+import { Eq, Unreachable } from './utils.js';
+import { Effects, Handlers, NameOfEffect, ExcludeHandledEffects, UsedEffectsInHandlers, Effectful } from './core.js';
 
 /**
  * Type constructor constructing message representing type

--- a/src/async-task.ts
+++ b/src/async-task.ts
@@ -1,5 +1,5 @@
-import { Effect, Effectful, HandleTactics, createPrimitive } from './core';
-import { unsafeRunAsync } from './runners';
+import { Effect, Effectful, HandleTactics, createPrimitive } from './core.js';
+import { unsafeRunAsync } from './runners.js';
 
 /**
  * Effect for computations rely on asynchronous tasks

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,4 @@
-import { Eq, UnionToIntersection, Delay, Simplify, isGenerator, Unreachable, withName } from './utils';
+import { Eq, UnionToIntersection, Delay, Simplify, isGenerator, Unreachable, withName } from './utils.js';
 
 /**
  * Constructor for types of values representing code

--- a/src/exception.ts
+++ b/src/exception.ts
@@ -1,4 +1,4 @@
-import { createPrimitives, Effect, Handlers } from './core';
+import { createPrimitives, Effect, Handlers } from './core.js';
 
 /**
  * Effect spec template for exception effects (similar to 'Either' or 'Result' monads)

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,4 @@
  * @packageDocumentation
  */
 
-export { Effect, Effects, createPrimitives, Effectful, HandleTactics, Handlers, handle, run } from './core'
+export { Effect, Effects, createPrimitives, Effectful, HandleTactics, Handlers, handle, run } from './core.js'

--- a/src/monad.ts
+++ b/src/monad.ts
@@ -1,4 +1,4 @@
-import { Effectful } from './core';
+import { Effectful } from './core.js';
 
 /**
  * Applies function to result of a computation

--- a/src/runners.ts
+++ b/src/runners.ts
@@ -1,7 +1,7 @@
-import { Effects, Code, HandleTactics, handle, run, Effectful, HandleError } from './core';
-import { Eq, Simplify, UnionToIntersection } from './utils';
+import { Effects, Code, HandleTactics, handle, run, Effectful, HandleError } from './core.js';
+import { Eq, Simplify, UnionToIntersection } from './utils.js';
 
-export { run } from './core'
+export { run } from './core.js'
 
 /**
  * Constructs type for handlers used at top level

--- a/src/with-handler.ts
+++ b/src/with-handler.ts
@@ -1,4 +1,4 @@
-import { Effectful, Effects, ExcludeHandledEffects, handle, Handlers, UsedEffectsInHandlers } from './core'
+import { Effectful, Effects, ExcludeHandledEffects, handle, Handlers, UsedEffectsInHandlers } from './core.js'
 
 /**
  * Wraps function with given handlers

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "moduleResolution": "bundler",
-    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "nodenext",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
     "exactOptionalPropertyTypes": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,


### PR DESCRIPTION
#32 

Now hyogwa can be used in both node and ts-node environment without bundlers.