### PR TITLE
Make `abort` tactic terminate computation currently handled

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -392,6 +392,7 @@ function* _handle<E extends Effects, R, const H extends Partial<Handlers<E, R>>>
           abort(value) {
             if (isCodeHandled) throw new HandleError(code, 'cannot call handle tactics more than once')
 
+            computation.return(value)
             result = value
             aborted = true
             isCodeHandled = true


### PR DESCRIPTION
Before this PR resources allocated by JS's new `using` declarations are not properly deallocated when the computation containing them is terminated by `abort` tactic. Now this is fixed.